### PR TITLE
Do not ignore source folder files when subfolder exist

### DIFF
--- a/Ai Merge.jsx
+++ b/Ai Merge.jsx
@@ -699,10 +699,11 @@ function getFilesInSubfolders( srcFolder ) {
         }
     }
 
-    if (theFolders.length == 0) {
-        theFileList = Array.prototype.concat.apply([], getFilesInFolder(srcFolder));
-    }
-    else {
+    /* use the files of the source folder as default */
+    theFileList = getFilesInFolder(srcFolder);
+    
+    /* get files from subfolders and merge into fileList */
+    if (theFolders.length > 0) {
         for (var x=0; x < theFolders.length; x++) {
             theFileList = Array.prototype.concat.apply(theFileList, getFilesInFolder(theFolders[x]));
         }

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ This script has only been tested on Adobe Illustrator CC 2014. It was written to
     
  6. The script will create a new Adobe Illustrator document with an artboard for each file. Please note that Adobe Illustrator allows up to 1,000 artboards so the script will only work on the first 1,000 files it finds.
   
- 9. If logging is enabled (in the startup dialog) the script will create a log file named `ai-script-log.txt` on the Desktop of your computer. To turn this off, set the variable named `logging` to `false` near the top of the script.
+ 9. If logging is enabled (in the startup dialog) the script will create a log file named `ai-script-log.txt` in the user's home directory. To turn this off, set the variable named `logging` to `false` near the top of the script.
  
  
 # The MIT License


### PR DESCRIPTION
See #2 
As soon as subfolders exist, the files in the source folder were ignored. 